### PR TITLE
upgrade action node engine to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     description: 'Twitter Access Token Secret is referenced here'
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'hash'


### PR DESCRIPTION
related to https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

once merged, I will create 2.0.0 release